### PR TITLE
Added command-line args handling: simple view mode, help, status url

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ apt-get install nodejs npm
 npm install blessed
 npm install process
 npm install markup-js
+npm install yargs
 ```
 
 # Run
-`nodejs nstatus.js http://demo.nginx.com`
+`nodejs nstatus.js http://demo.nginx.com/status`
 
 # TODOs
 * Tabs other than main
 * URLs other than demo.nginx.com
-


### PR DESCRIPTION
**examples**:
Don't pass all required arguments:

```
node nstatus.js
Loading ...
Usage: nstatus.js [options] <url>

Options:
  -h, --help    Show help                                              [boolean]
  -s, --simple  Simple view mode on                   [boolean] [default: false]

Examples:
  nstatus.js http://demo.nginx.com/status  Shows stats from
                                           demo.nginx.com/status
```

Start normally:

```
node nstatus.js http://demo.nginx.com/status
```

Start with the simple view mode enabled:

```
node nstatus.js -s http://demo.nginx.com/status
```

Show help:

```
node nstatus.js -h
```
